### PR TITLE
New heartbeat kustoqueries

### DIFF
--- a/queries/unix_heartbeat.kusto
+++ b/queries/unix_heartbeat.kusto
@@ -1,10 +1,10 @@
 // Track VM availability 
 // Display the VM's reported availability during the last 5 minutes.
 Heartbeat
-| summarize LH = arg_max(TimeGenerated, *) by Computer
+| extend affected_object = toupper(tostring(split(_ResourceId, "/") [-1]))
+| summarize LH = arg_max(TimeGenerated, *) by affected_object
 | where LH < ago(5m)
 | where OSType contains_cs "Linux"
-| extend affected_object = tostring(split(_ResourceId, "/") [-1])
 | extend monitor_package = "AZ_UNIX_BASEPOLICY"
 | extend monitor_name = "AZ_UNIX_HEARTBEAT"
 | extend monitor_description = "Checks availability of the Host"

--- a/queries/unix_heartbeat.kusto
+++ b/queries/unix_heartbeat.kusto
@@ -1,17 +1,18 @@
 // Track VM availability 
 // Display the VM's reported availability during the last 5 minutes.
 Heartbeat
-    | summarize LH = arg_max(TimeGenerated, *) by Computer
-    | where LH < ago(5m)
-    | where OSType contains_cs "Linux"
-    | extend affected_object = tostring(split(_ResourceId, "/") [-1])
-    | extend monitor_package = "AZ_UNIX_BASEPOLICY"
-    | extend monitor_name = "AZ_UNIX_HEARTBEAT"
-    | extend monitor_description = "Checks availability of the Host"
-    | extend script_name = "n/a"
-    | extend script_version = "n/a"
-    | extend threshold = "00:05:00"
-    | extend value = LH
-    | extend state = iff(datetime_diff("second", now(), LH) >= 300, "CRITICAL", "OK")
-    | extend additional_information = "The Host did not send Heartbeats anymore."
-    | project TimeGenerated=now(), _ResourceId, state, affected_object=Computer, monitor_package, monitor_name, monitor_description, script_name, script_version, threshold, value, affected_entity=Computer, additional_information
+| summarize LH = arg_max(TimeGenerated, *) by Computer
+| where LH < ago(5m)
+| where OSType contains_cs "Linux"
+| extend affected_object = tostring(split(_ResourceId, "/") [-1])
+| extend monitor_package = "AZ_UNIX_BASEPOLICY"
+| extend monitor_name = "AZ_UNIX_HEARTBEAT"
+| extend monitor_description = "Checks availability of the Host"
+| extend script_name = "n/a"
+| extend script_version = "n/a"
+| extend threshold = "00:05:00"
+| extend value = LH
+| extend state = iff(datetime_diff("second", now(), LH) >= 300, "CRITICAL", "OK")
+| extend additional_information = "The Host did not send Heartbeats anymore."
+| project TimeGenerated=now(), _ResourceId, state, affected_object, monitor_package, monitor_name, monitor_description, script_name, script_version, threshold, value, affected_entity=Computer, additional_information
+

--- a/queries/windows_heartbeat.kusto
+++ b/queries/windows_heartbeat.kusto
@@ -1,5 +1,8 @@
+// Track VM availability 
+// Display the VM's reported availability during the last 5 minutes.
 Heartbeat
-    | summarize LH = arg_max(TimeGenerated, *) by Computer
+    | extend affected_object = toupper(tostring(split(_ResourceId, "/") [-1]))
+    | summarize LH = arg_max(TimeGenerated, *) by affected_object
     | where LH < ago(5m)
     | where OSType contains_cs "Windows"
     | extend monitor_package = "AZ_NT_BASEPOLICY"
@@ -11,4 +14,5 @@ Heartbeat
     | extend value = LH
     | extend state = iff(datetime_diff("second", now(), LH) >= 300, "CRITICAL", "OK")
     | extend additional_information = ""
-    | project TimeGenerated=now(), _ResourceId, state, affected_object=Computer, monitor_package, monitor_name, monitor_description, script_name, script_version, threshold, value, affected_entity=Computer, additional_information
+    | project TimeGenerated=now(), _ResourceId, state, affected_object, monitor_package, monitor_name, monitor_description, script_name, script_version, threshold, value, affected_entity=Computer, additional_information
+


### PR DESCRIPTION
# Description

The summize function have been changed from (by) Computer to (by) affected_object as a part of the _ResourceID.
The heartbeat data stream is thus unambiguous.

Example:

| extend **affected_object** = toupper(tostring(split(**_ResourceId**, "/") [**-1**]))
| summarize LH = arg_max(TimeGenerated, *) by **affected_object**


# Change overview (tick true):

- [ ] This introduces backward incompatible changes
- [ ] This adds a new backward compatible Feature
- [x] This fixes a Bug

# Version information: 
- [] Current Version: `major.minor.patch`
- [x] Next Version based on [Semantic Versioning](https://semver.org/) (see above): `v1.1.0`

# How Has This Been Tested?

The heartbeat Kustoqueries were tested in a log analytics workspace (law) environment - Azure -
<!-- You should always do some tests! -->

- [x] Apply of all examples was successfull

# Checklist:

- [x] I have run tests and documented them above
- [x] I have performed a self-review of my own code
- [x] I have updated the documentation
